### PR TITLE
Mac commands

### DIFF
--- a/src/arduino-rfm/Config.h
+++ b/src/arduino-rfm/Config.h
@@ -1,6 +1,9 @@
 //Uncomment for debug 
 //#define DEBUG
 
+// Debug only MAC layer
+#define DEBUG_MAC
+
 // Define max payload size used for this node
 #define MAX_UPLINK_PAYLOAD_SIZE    220  
 #define MAX_DOWNLINK_PAYLOAD_SIZE   220

--- a/src/arduino-rfm/Conversions.cpp
+++ b/src/arduino-rfm/Conversions.cpp
@@ -66,7 +66,7 @@ void Hex2ASCII(unsigned char ASCII, unsigned char *Upper_Nibble, unsigned char *
 unsigned char ASCII2Hex(unsigned char Upper_Nibble, unsigned char Lower_Nibble)
 {
 
-  unsigned char ASCII;
+  unsigned char ASCII = 0;
 
     // High Nibble
     if(Upper_Nibble >= '0' && Upper_Nibble <= '9')

--- a/src/arduino-rfm/LoRaMAC.h
+++ b/src/arduino-rfm/LoRaMAC.h
@@ -45,6 +45,22 @@
 
 typedef enum {NO_RFM_COMMAND, NEW_RFM_COMMAND, RFM_COMMAND_DONE, JOIN} RFM_command_t;
 
+typedef enum {
+    COMMAND_LINK_CHECK      = 0x02,
+    COMMAND_LINK_ADR        = 0x03,
+    COMMAND_DUTY_CYCLE      = 0X04,
+    COMMAND_RX_PARAM_SETUP  = 0x05,
+    COMMAND_DEV_STATUS      = 0x06,
+    COMMAND_NEW_CHANNEL     = 0x07,
+    COMMAND_RX_TIMING_SETUP = 0x08,
+    COMMAND_TX_PARAM_SETUP  = 0x09,
+    COMMAND_DIC_CHANNEL     = 0x0A,
+    COMMAND_DEV_TIME        = 0x0D
+
+}
+macComands_t;
+
+
 /*
 *****************************************************************************************
 * FUNCTION PROTOTYPES

--- a/src/arduino-rfm/Struct.h
+++ b/src/arduino-rfm/Struct.h
@@ -62,6 +62,8 @@ typedef struct {
     unsigned int  *Frame_Counter;
     unsigned char GwCount;          // Gateway count sent in last LinkCheckAns
     unsigned char Margin;           // Margin sent in last LinkCheckAns
+    unsigned char RX1Delay;
+    unsigned char RX1DelayPending;  // If the node must send RXTimingSetupAns
 } sLoRa_Session;
 
 typedef struct {

--- a/src/arduino-rfm/Struct.h
+++ b/src/arduino-rfm/Struct.h
@@ -60,6 +60,8 @@ typedef struct {
     unsigned char *AppSKey;
     unsigned char *DevAddr;
     unsigned int  *Frame_Counter;
+    unsigned char GwCount;          // Gateway count sent in last LinkCheckAns
+    unsigned char Margin;           // Margin sent in last LinkCheckAns
 } sLoRa_Session;
 
 typedef struct {
@@ -94,6 +96,8 @@ typedef struct {
     unsigned char Channel_Rx;		//See RFM filed
     unsigned char Channel_Hopping;	//0x00 No hopping, 0x01 Hopping
     unsigned char Transmit_Power;	//0x00 to 0x0F
+    unsigned long LinkCheckInterval; // in millis
+    unsigned long LastLinkCheck;     // millis() of last LinkCheckReq sent
 } sSettings;
 
 typedef enum {
@@ -158,6 +162,16 @@ typedef enum {CLASS_A, CLASS_C} devclass_t;
 typedef enum {NO_RX, NEW_RX} rx_t;
 
 typedef enum {NO_ACK, NEW_ACK} ack_t;
+
+typedef enum {
+    JOIN_REQ_MTYPE          = 0b00000000,
+    JOIN_ACK_MTYPE          = 0b00100000,
+    UNCONFIRMED_UPLINK      = 0b01000000,
+    UNCONFIRMED_DOWNLINK    = 0b01100000,
+    CONFIRMED_UPLINK        = 0b10000000,
+    CONFIRMED_DOWNLINK      = 0b10100000,    
+}
+mtype_t;
 
 #endif
 

--- a/src/arduino-rfm/Struct.h
+++ b/src/arduino-rfm/Struct.h
@@ -64,6 +64,8 @@ typedef struct {
     unsigned char Margin;           // Margin sent in last LinkCheckAns
     unsigned char RX1Delay;
     unsigned char RX1DelayPending;  // If the node must send RXTimingSetupAns
+    unsigned char RX1DRoffset;
+    unsigned char RX2Datarate;
 } sLoRa_Session;
 
 typedef struct {

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -70,6 +70,10 @@ bool LoRaWANClass::init(void)
     Session_Data.RX1Delay = 1;
     Session_Data.RX1DelayPending = 0;
 
+    #ifdef EU_868
+    Session_Data.RX2Datarate = SF12BW125;   //set RX2 datarate 12
+    #endif
+
     //Initialize OTAA data struct
     memset(DevEUI, 0x00, 8);
     memset(AppEUI, 0x00, 8);

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -66,7 +66,9 @@ bool LoRaWANClass::init(void)
     Session_Data.NwkSKey = NwkSKey;
     Session_Data.AppSKey = AppSKey;
     Session_Data.DevAddr = Address_Tx;
-    Session_Data.Frame_Counter = &Frame_Counter_Tx;
+    Session_Data.Frame_Counter = &Frame_Counter_Tx;    
+    Session_Data.RX1Delay = 1;
+    Session_Data.RX1DelayPending = 0;
 
     //Initialize OTAA data struct
     memset(DevEUI, 0x00, 8);
@@ -108,6 +110,7 @@ bool LoRaWANClass::init(void)
 
     LoRa_Settings.Confirm = 0x00; //0x00 unconfirmed, 0x01 confirmed
     LoRa_Settings.Channel_Hopping = 0x00; //0x00 no channel hopping, 0x01 channel hopping
+    
 
     // Initialise buffer for data to transmit
     memset(Data_Tx, 0x00, sizeof(Data_Tx));

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -277,7 +277,6 @@ void LoRaWANClass::sendUplink(char *data, unsigned int len, unsigned char confir
         randomChannel();
     }
     LoRa_Settings.Confirm = (confirm == 0) ? 0 : 1;	
-    if (mport == 0) mport = 1;
     if (mport > 223) mport = 1;	
     LoRa_Settings.Mport = mport;
     //Set new command for RFM
@@ -447,6 +446,21 @@ void LoRaWANClass::setFrameCounter(unsigned int FrameCounter) {
     Frame_Counter_Tx = FrameCounter;
 }
 
+/**
+ * @brief Set interval between LinkCheckReq
+ * if interval is 0 no LinkCheck is sent.
+ * 
+ * 
+ * @param interval Interval in days. 
+ */
+void LoRaWANClass::setLinkCheckInterval(unsigned long interval)
+{
+    if (interval<0)
+        return;
+    
+    this->LoRa_Settings.LinkCheckInterval = interval;
+    this->LoRa_Settings.LastLinkCheck = millis();
+}
 
 
 // define lora objet 

--- a/src/arduino-rfm/lorawan-arduino-rfm.h
+++ b/src/arduino-rfm/lorawan-arduino-rfm.h
@@ -82,7 +82,8 @@ class LoRaWANClass
         int readData(char *outBuff);
         bool readAck(void);
         void update(void);
-
+        void setLinkCheckInterval(unsigned long interval);
+        
         // frame counter
         unsigned int getFrameCounter();
         void setFrameCounter(unsigned int FrameCounter);


### PR DESCRIPTION
DO NOT MERGE.

This pull request has some MAC commands  support, 

To be able to implement support for other commands, like ADR, some changes needs to be done in the way channels and frequencies are stored. ADR and some other commands modify enabled channels, frequencies and data rates.
As different regions manage this information in different ways I publish this branch to discuss how to do it in a way it fits all regions.

LinkCheck has been tested with ChirpStack.
RXTimingSetupReq and  JoinAccept parameters has been tested with ChirpStack but are necessary to work with TTN Stack V3 which uses an RX1 Delay of 5s by default.

Only tested in EU_868

Miguel