### PR TITLE
Fix for missing ACK of confirmed msg on Class C EU868

### DIFF
--- a/src/arduino-rfm/RFM95.cpp
+++ b/src/arduino-rfm/RFM95.cpp
@@ -698,21 +698,11 @@ void RFM_Continuous_Receive(sSettings *LoRa_Settings)
   RFM_Write(RFM_REG_INVERT_IQ, 0x67);
   RFM_Write(RFM_REG_INVERT_IQ2, 0x19);
   
-	//Change Datarate and channel.
-  // This depends on regional parameters
-#ifdef EU_868
-  RFM_Change_Datarate(SF12BW125);
-  RFM_Change_Channel(CHRX2);
-#else
-  //Datarate for downlink should be 8 but testing on 10
-  //LoRa_Settings->Datarate_Rx=10;
-  //LoRa_Settings->Channel_Rx=0;
-  //Serial.println("DataRate Rx "+String(LoRa_Settings->Datarate_Rx));
-  //Serial.println("Cannel Rx "+String(LoRa_Settings->Channel_Rx));
-  
-	RFM_Change_Datarate(LoRa_Settings->Datarate_Rx);
-	RFM_Change_Channel(LoRa_Settings->Channel_Rx);
-#endif
+  //Change Datarate
+  RFM_Change_Datarate(LoRa_Settings->Datarate_Rx);
+
+  //Change Channel
+  RFM_Change_Channel(LoRa_Settings->Channel_Rx);
 
 	//Switch to continuous receive
 	RFM_Switch_Mode(RFM_MODE_RXCONT);


### PR DESCRIPTION
Through testing I found that my device would not receive an acknowledgement to an confirmed uplink with the hardcoded datarate and channel defined for the EU868 hardware config. Changing this to allow the daterate and channel to be set by the values within LoRa_Settings resulted in consistent uplink acknowledgements. 

Hardware used during testing:

- MCU: ESP32-WROOM-32E
- LoRa Module: RFM95C

LoRaWAN parameters used during testing:

- DeviceClass: CLASS_C
- DataRate: SF7BW125
- Channel: MULTI