### PR TITLE
change default region on Config.h and fix subband selection for US915 and AU915

### DIFF
--- a/src/arduino-rfm/Config.h
+++ b/src/arduino-rfm/Config.h
@@ -13,15 +13,14 @@
 #define MAX_DOWNLINK_PAYLOAD_SIZE 220
 
 #if !defined(AS_923) && !defined(AS_923_2) && !defined(EU_868) && !defined(US_915) && !defined(AU_915)
-
-//Default LoRaWAN freq band
-#define EU_868
+#define US_915  // Define default Region
+#endif
 
 #ifdef US_915
-//Select the subband youre working on
-// make sure your gateway is working in one of these bands
-#define SUBND_0 // 902.3 - 903.7 Mhz
-//#define SUBND_1     // 903.9 - 905.3 Mhz TTN
+//Select the subband you're working on
+// make sure your gateway is working with the selected subband
+//#define SUBND_0     // 902.3 - 903.7 Mhz
+#define SUBND_1     // 903.9 - 905.3 Mhz
 //#define SUBND_2     // 905.5 - 906.9 Mhz
 //#define SUBND_3     // 907.1 - 908.5 Mhz
 //#define SUBND_4     // 908.7 - 910.1 Mhz
@@ -31,9 +30,9 @@
 #endif
 
 #ifdef AU_915
-//Select the subband youre working on
-// make sure your gateway is working in one of these bands
-#define SUBND_0 // 915.2 - 916.6 Mhz
+//Select the subband you're working on
+// make sure your gateway is working with the selected subband
+#define SUBND_0     // 915.2 - 916.6 Mhz
 //#define SUBND_1     // 916.8 - 918.2 Mhz
 //#define SUBND_2     // 918.4 - 919.8 Mhz
 //#define SUBND_3     // 920.0 - 921.4 Mhz
@@ -41,5 +40,4 @@
 //#define SUBND_5     // 923.2 - 924.6 Mhz
 //#define SUBND_6     // 924.8 - 926.2 Mhz
 //#define SUBND_7     // 926.4 - 927.8 Mhz
-#endif
 #endif


### PR DESCRIPTION
When we select the US915 or AU915 regions, the settings will not select the subband due to this statement

```c
#if !defined(AS_923) && !defined(AS_923_2) && !defined(EU_868) && !defined(US_915) && !defined(AU_915)
```

because the `#endif` closes at the end of the file.

I defined the US915 as default region