### PR TITLE
Adding support for IN_865

### DIFF
--- a/src/arduino-rfm/Config.h
+++ b/src/arduino-rfm/Config.h
@@ -7,12 +7,13 @@
 //#define EU_868
 //#define US_915
 //#define AU_915
+#define IN_865
 
 // Define max payload size used for this node
 #define MAX_UPLINK_PAYLOAD_SIZE 220
 #define MAX_DOWNLINK_PAYLOAD_SIZE 220
 
-#if !defined(AS_923) && !defined(AS_923_2) && !defined(EU_868) && !defined(US_915) && !defined(AU_915)
+#if !defined(AS_923) && !defined(AS_923_2) && !defined(EU_868) && !defined(US_915) && !defined(AU_915) &&!defined(IN_865)
 #define US_915  // Define default Region
 #endif
 

--- a/src/arduino-rfm/LoRaMAC.cpp
+++ b/src/arduino-rfm/LoRaMAC.cpp
@@ -77,6 +77,8 @@ void LORA_Cycle(sBuffer *Data_Tx, sBuffer *Data_Rx, RFM_command_t *RFM_Command, 
     unsigned char rx1_dr = LoRa_Settings->Datarate_Tx+10;
 	#elif defined(EU_868)   
     unsigned char rx1_dr = LoRa_Settings->Datarate_Tx;
+	#elif defined(IN_865)
+	unsigned char rx1_dr = LoRa_Settings->Datarate_Tx;
 	#else // AS_923 and AS_923_2
 	unsigned char rx1_dr = LoRa_Settings->Datarate_Tx;
 	#endif
@@ -103,6 +105,9 @@ void LORA_Cycle(sBuffer *Data_Tx, sBuffer *Data_Rx, RFM_command_t *RFM_Command, 
 			#elif defined(EU_868)
 			LoRa_Settings->Channel_Rx = CHRX2;    // set Rx2 channel 923.3 MHZ 
 			LoRa_Settings->Datarate_Rx = SF12BW125;   //set RX2 datarate 12
+			#elif defined(IN_865)
+			LoRa_Settings->Channel_Rx = CHRX2;    // set Rx2 channel 866.550 MHZ 
+			LoRa_Settings->Datarate_Rx = SF10BW125;   //set RX2 datarate 10
 			#elif defined(AS_923) || defined(AS_923_2)
 			LoRa_Settings->Channel_Rx = 0x00;    // set Rx2 channel 923.2 (AS_923) or 921.4 (AS_923_2)
 			LoRa_Settings->Datarate_Rx = SF10BW125;   //set RX2 datarate 10
@@ -141,6 +146,9 @@ void LORA_Cycle(sBuffer *Data_Tx, sBuffer *Data_Rx, RFM_command_t *RFM_Command, 
 			#elif defined(EU_868)
 			LoRa_Settings->Channel_Rx = CHRX2;    // set Rx2 channel 923.3 MHZ 
 			LoRa_Settings->Datarate_Rx = SF12BW125;   //set RX2 datarate 12
+			#elif defined(IN_865)
+			LoRa_Settings->Channel_Rx = CHRX2;    // set Rx2 channel 866.550 MHZ 
+			LoRa_Settings->Datarate_Rx = SF10BW125;   //set RX2 datarate 10
 			#elif defined(AS_923) || defined(AS_923_2)
 			LoRa_Settings->Channel_Rx = 0x00;    // set Rx2 channel 923.2 (AS_923) or 921.4 (AS_923_2)
 			LoRa_Settings->Datarate_Rx = SF10BW125;   //set RX2 datarate 10
@@ -166,6 +174,9 @@ void LORA_Cycle(sBuffer *Data_Tx, sBuffer *Data_Rx, RFM_command_t *RFM_Command, 
 		#elif defined(EU_868)
 		LoRa_Settings->Channel_Rx = CHRX2;    // set Rx2 channel 923.3 MHZ 
 		LoRa_Settings->Datarate_Rx = SF12BW125;   //set RX2 datarate 12
+		#elif defined(IN_865)
+		LoRa_Settings->Channel_Rx = CHRX2;    // set Rx2 channel 866.550 MHZ 
+		LoRa_Settings->Datarate_Rx = SF10BW125;   //set RX2 datarate 10
 		#elif defined(AS_923) || defined(AS_923_2)
 		LoRa_Settings->Channel_Rx = 0x00;    // set Rx2 channel 923.2 (AS_923) or 921.4 (AS_923_2)
 		LoRa_Settings->Datarate_Rx = SF10BW125;   //set RX2 datarate 10

--- a/src/arduino-rfm/Struct.h
+++ b/src/arduino-rfm/Struct.h
@@ -100,13 +100,17 @@ typedef enum {
   CH0 = 0,
   CH1 = 1,
   CH2 = 2,
+#ifndef IN_865 //IN_865 only supports 3 channels
   CH3 = 3,
   CH4 = 4,
   CH5 = 5,
   CH6 = 6,
   CH7 = 7,
+#endif
 #ifdef EU_868
   CHRX2 = 8,
+#elif defined(IN_865)
+  CHRX2 = 3,
 #else
   CH8 = 8,
 #endif
@@ -158,6 +162,13 @@ typedef enum {
     SF8BW125    = 0x04,
     SF7BW125    = 0x05,
     SF7BW250    = 0x06
+#elif defined(IN_865)
+    SF12BW125   = 0x00,
+    SF11BW125   = 0x01,
+    SF10BW125   = 0x02,
+    SF9BW125    = 0x03,
+    SF8BW125    = 0x04,
+    SF7BW125    = 0x05
 #endif
 } dataRates_t;
 

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -88,6 +88,8 @@ bool LoRaWANClass::init(void)
     LoRa_Settings.Datarate_Rx = 0x02; //set to SF10 BW 125 kHz
 #elif defined(EU_868)
     LoRa_Settings.Datarate_Rx = 0x03;                //set to SF9 BW 125 kHz
+#elif defined(IN_865)
+    LoRa_Settings.Datarate_Rx = 0x02;               //set to SF10 BW 125 kHz
 #else //US_915 or AU_915
     LoRa_Settings.Datarate_Rx = 0x0C;                //set to SF8 BW 500 kHz
 #endif
@@ -347,6 +349,8 @@ void LoRaWANClass::setChannel(unsigned char channel)
         LoRa_Settings.Channel_Rx = channel + 0x08;
 #elif defined(EU_868)
         LoRa_Settings.Channel_Rx = channel;
+#elif defined(IN_865)
+        LoRa_Settings.Channel_Rx = channel;
 #elif defined(AS_923) || defined(AS_923_2)
         LoRa_Settings.Channel_Rx = channel;
 #endif
@@ -467,6 +471,9 @@ void LoRaWANClass::randomChannel()
 	LoRa_Settings.Channel_Rx=freq_idx;      // same rx and tx channel
 #elif defined(EU_868)    
     freq_idx = random(0,8);
+    LoRa_Settings.Channel_Rx=freq_idx;      // same rx and tx channel 
+#elif defined(IN_865)
+    freq_idx = random(0,4);
     LoRa_Settings.Channel_Rx=freq_idx;      // same rx and tx channel 
 #else // US_915 or AU_915
     freq_idx = random(0, 8);

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -473,7 +473,7 @@ void LoRaWANClass::randomChannel()
     freq_idx = random(0,8);
     LoRa_Settings.Channel_Rx=freq_idx;      // same rx and tx channel 
 #elif defined(IN_865)
-    freq_idx = random(0,4);
+    freq_idx = random(0,3);
     LoRa_Settings.Channel_Rx=freq_idx;      // same rx and tx channel 
 #else // US_915 or AU_915
     freq_idx = random(0, 8);


### PR DESCRIPTION
Added support for IN_865 band in accordance to issue #169,

Hardware used during testing:
- LILYGO TTGO LoRa32 V1 (as node)
- Waveshare SX1302 LoRaWAN Gateway HAT (with Rpi 4)

(with Chirpstack LNS)

Parameters tested:
- Sending uplinks on all channels and all data rates.
- Receiving downlinks with class A and class C.