### PR TITLE
Make SPI pins configurable

### DIFF
--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -42,7 +42,7 @@ LoRaWANClass::~LoRaWANClass()
 {
 }
 
-bool LoRaWANClass::init(void)
+bool LoRaWANClass::init(int8_t clk_pin, int8_t miso_pin, int8_t mosi_pin, int8_t ss_pin)
 {
     // Lora Setting Class
     dev_class = CLASS_A;
@@ -141,7 +141,7 @@ bool LoRaWANClass::init(void)
     digitalWrite(RFM_pins.RST, HIGH);
 
     //Initialise the SPI port
-    SPI.begin();
+    SPI.begin(clk_pin, miso_pin, mosi_pin, ss_pin);
 
     /*** This prevents the use of other SPI devices with different settings ***/
     //SPI.beginTransaction(SPISettings(4000000,MSBFIRST,SPI_MODE0));

--- a/src/arduino-rfm/lorawan-arduino-rfm.h
+++ b/src/arduino-rfm/lorawan-arduino-rfm.h
@@ -59,7 +59,7 @@ public:
     LoRaWANClass();
     ~LoRaWANClass();
 
-    bool init(void);
+    bool init(int8_t clk_pin=-1, int8_t miso_pin=-1, int8_t mosi_pin=-1, int8_t ss_pin=-1);
     bool join(void);
     void sleep(void);
     void wakeUp(void);


### PR DESCRIPTION
I wanted to be able to choose which pins the SPI uses for communication but this was not yet possible.
The default values for the pin assignment are still < 0 so the default values should apply and the change
should be backward compatible.

I also noted that there is a hard coded analogue read on pin 0 to get a random seed.
The ESP32-S2 for example has no ADC on pin 0 which will make it fail.
Is this already on the roadmap?