### PR TITLE
DIO pin optional

### DIFF
--- a/src/arduino-rfm/RFM95.h
+++ b/src/arduino-rfm/RFM95.h
@@ -94,6 +94,11 @@ typedef enum {
     RFM_MODE_LORA       = 0b10000000
     } frm_mode_t;
 
+typedef enum {
+    IRQ_RX_TIMEOUT_MASK     = 0b10000000,
+    IRQ_RX_DONE_MASK        = 0b01000000,
+    IRQ_TX_DONE_MASK        = 0b00001000
+    } irq_mask;
 
 /*
 *****************************************************************************************
@@ -109,6 +114,7 @@ message_t RFM_Get_Package(sBuffer *RFM_Rx_Package);
 void RFM_Write(unsigned char RFM_Address, unsigned char RFM_Data);
 void RFM_Switch_Mode(unsigned char Mode);
 void RFM_Set_Tx_Power(int level, int outputPin);
+bool RFM_isRxDone();
 void RFM_Set_OCP(unsigned char mA);
 
 unsigned char RFM_Get_Rssi();

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -122,23 +122,28 @@ bool LoRaWANClass::init(void)
     Message_Rx.Direction = 0x01; //Set down direction for Rx message
 
     //Initialize I/O pins
-    pinMode(RFM_pins.DIO0, INPUT);
-    pinMode(RFM_pins.DIO1, INPUT);
+    if (RFM_pins.DIO0 != -1)
+    {
+        pinMode(RFM_pins.DIO0, INPUT);
+        pinMode(RFM_pins.DIO1, INPUT);
+        pinMode(RFM_pins.DIO2, INPUT);
+    }
 #ifdef BOARD_DRAGINO_SHIELD
     pinMode(RFM_pins.DIO5, INPUT);
 #endif
-    pinMode(RFM_pins.DIO2, INPUT);
     pinMode(RFM_pins.CS, OUTPUT);
-    pinMode(RFM_pins.RST, OUTPUT);
-
     digitalWrite(RFM_pins.CS, HIGH);
 
     // Reset
-    digitalWrite(RFM_pins.RST, HIGH);
-    delay(10);
-    digitalWrite(RFM_pins.RST, LOW);
-    delay(10);
-    digitalWrite(RFM_pins.RST, HIGH);
+    if (RFM_pins.RST != -1)
+    {
+        pinMode(RFM_pins.RST, OUTPUT);
+        digitalWrite(RFM_pins.RST, HIGH);
+        delay(10);
+        digitalWrite(RFM_pins.RST, LOW);
+        delay(10);
+        digitalWrite(RFM_pins.RST, HIGH);
+    }
 
     //Initialise the SPI port
     SPI.begin();
@@ -495,7 +500,16 @@ void LoRaWANClass::update(void)
         }
 
         //Receive in Class C mode
-        if (digitalRead(RFM_pins.DIO0) == HIGH )
+        bool isRxDone;
+        if (RFM_pins.DIO0 != -1)
+        {
+            isRxDone = digitalRead(RFM_pins.DIO0) == HIGH;
+        }
+        else
+        {
+            isRxDone = RFM_isRxDone();
+        }
+        if (isRxDone)
         {
             LORA_Receive_Data(&Buffer_Rx, &Session_Data, &OTAA_Data, &Message_Rx, &LoRa_Settings);
             if (Buffer_Rx.Counter != 0x00)


### PR DESCRIPTION
Hello,

I realize my previous pull request (https://github.com/ElectronicCats/Beelan-LoRaWAN/pull/184) was not very "pull request friendly." It contained several distinct objectives, making it challenging to discuss and merge.

To improve clarity and ease of review, I've decided to break down the changes into separate pull requests. This pull request focuses on making the DIO pin optional.

The upcoming pull requests will address modifications to make the code more "deep sleep friendly" for ESP devices, customizable RX delay and windows (note that Things Stack uses a 5-second delay for RX1), and lastly, cleaning up the TX power settings.

Thanks,

