### PR TITLE
To fix frequencies for AS923 (AS923-1) to use 920-923Mhz in use by recent gateways

### DIFF
--- a/src/arduino-rfm/RFM95.cpp
+++ b/src/arduino-rfm/RFM95.cpp
@@ -236,16 +236,15 @@
     { 0xE7, 0xE0, 0x27}, //Rcv Channel [7] 927.5 Mhz / 61.035 Hz = 15196199 = 0xE7E027
   };
 #elif defined(AS_923)
-  static const PROGMEM unsigned char LoRa_Frequency[9][3] = {//[923.2 - 924.8] MHz
-    { 0xE6, 0xCC, 0xF4 }, //Channel [0], 923.2 MHz / 61.035 Hz = 15125748 = 0xE6CCF4
-    { 0xE6, 0xD9, 0xC0 }, //Channel [1], 923.4 MHz / 61.035 Hz = 15129024 = 0xE6D9C0
-    { 0xE6, 0xE6, 0x8D }, //Channel [2], 923.6 MHz / 61.035 Hz = 15132301 = 0xE6E68D
-    { 0xE6, 0xF3, 0x5A }, //Channel [3], 923.8 MHz / 61.035 Hz = 15135578 = 0xE6F35A
-    { 0xE7, 0x00, 0x27 }, //Channel [4], 924.0 MHz / 61.035 Hz = 15138855 = 0xE70027
-    { 0xE7, 0x0C, 0xF4 }, //Channel [5], 924.2 MHz / 61.035 Hz = 15142132 = 0xE70CF4
-    { 0xE7, 0x19, 0xC0 }, //Channel [6], 924.4 MHz / 61.035 Hz = 15145408 = 0xE719C0
-    { 0xE7, 0x26, 0x8D }, //Channel [7], 924.6 MHz / 61.035 Hz = 15148685 = 0xE7268D
-    { 0xE7, 0x33, 0x5A }, //Channel [8], 924.8 MHz / 61.035 Hz = 15151962 = 0xE7335A
+  static const PROGMEM unsigned char LoRa_Frequency[8][3] = {//[922.0 - 923.4] MHz - New AS923/AS923-1 (920-923Mhz)
+    { 0xE6, 0x59, 0xC0 }, //Channel [0], 923.2 MHz / 61.035 Hz = 15125747 = 0xE6CCF3 - Default OTAA - RX2
+    { 0xE6, 0x66, 0x8D }, //Channel [1], 923.4 MHz / 61.035 Hz = 15129024 = 0xE6D9C0 - Default OTAA
+    { 0xE6, 0x8C, 0xF3 }, //Channel [2], 922.2 MHz / 61.035 Hz = 15109363 = 0xE68CF3
+    { 0xE6, 0x99, 0xC0 }, //Channel [3], 922.4 MHz / 61.035 Hz = 15112640 = 0xE699C0
+    { 0xE6, 0xA6, 0x8D }, //Channel [4], 922.6 MHz / 61.035 Hz = 15115917 = 0xE6A68D
+    { 0xE6, 0xB3, 0x5A }, //Channel [5], 922.8 MHz / 61.035 Hz = 15119194 = 0xE6B35A
+    { 0xE6, 0xA6, 0x8D }, //Channel [6], 923.0 MHz / 61.035 Hz = 15122471 = 0xE6C027
+    { 0xE6, 0x80, 0x27 }, //Channel [7], 922.0 MHz / 61.035 Hz = 15106087 = 0xE68027
   };
 #elif defined(AS_923_2)
   static const PROGMEM unsigned char LoRa_Frequency[8][3] = {//[921.4 - 922.8] MHz

--- a/src/arduino-rfm/RFM95.cpp
+++ b/src/arduino-rfm/RFM95.cpp
@@ -237,13 +237,13 @@
   };
 #elif defined(AS_923)
   static const PROGMEM unsigned char LoRa_Frequency[8][3] = {//[922.0 - 923.4] MHz - New AS923/AS923-1 (920-923Mhz)
-    { 0xE6, 0x59, 0xC0 }, //Channel [0], 923.2 MHz / 61.035 Hz = 15125747 = 0xE6CCF3 - Default OTAA - RX2
-    { 0xE6, 0x66, 0x8D }, //Channel [1], 923.4 MHz / 61.035 Hz = 15129024 = 0xE6D9C0 - Default OTAA
+    { 0xE6, 0xCC, 0xF4 }, //Channel [0], 923.2 MHz / 61.035 Hz = 15125748 = 0xE6CCF4 - Default OTAA - RX2
+    { 0xE6, 0xD9, 0xC0 }, //Channel [1], 923.4 MHz / 61.035 Hz = 15129024 = 0xE6D9C0 - Default OTAA
     { 0xE6, 0x8C, 0xF3 }, //Channel [2], 922.2 MHz / 61.035 Hz = 15109363 = 0xE68CF3
     { 0xE6, 0x99, 0xC0 }, //Channel [3], 922.4 MHz / 61.035 Hz = 15112640 = 0xE699C0
     { 0xE6, 0xA6, 0x8D }, //Channel [4], 922.6 MHz / 61.035 Hz = 15115917 = 0xE6A68D
     { 0xE6, 0xB3, 0x5A }, //Channel [5], 922.8 MHz / 61.035 Hz = 15119194 = 0xE6B35A
-    { 0xE6, 0xA6, 0x8D }, //Channel [6], 923.0 MHz / 61.035 Hz = 15122471 = 0xE6C027
+    { 0xE6, 0xC0, 0x27 }, //Channel [6], 923.0 MHz / 61.035 Hz = 15122471 = 0xE6C027
     { 0xE6, 0x80, 0x27 }, //Channel [7], 922.0 MHz / 61.035 Hz = 15106087 = 0xE68027
   };
 #elif defined(AS_923_2)

--- a/src/arduino-rfm/lorawan-arduino-rfm.cpp
+++ b/src/arduino-rfm/lorawan-arduino-rfm.cpp
@@ -566,9 +566,8 @@ void LoRaWANClass::randomChannel()
 {
     unsigned char freq_idx;
 #ifdef AS_923
-    freq_idx = random(0, 9);
-    // limit drate, ch 8 -> sf7bw250
-    LoRa_Settings.Datarate_Tx = freq_idx == 0x08? 0x06 : drate_common;
+	freq_idx = random(0, 8);
+	LoRa_Settings.Channel_Rx=freq_idx;      // same rx and tx channel
 #elif defined(AS_923_2)
     freq_idx = random(0, 8);
 	LoRa_Settings.Channel_Rx=freq_idx;      // same rx and tx channel


### PR DESCRIPTION
To use new AS923 (AS923-1) in 920-923Mhz.
Early AS923 in 923-925Mhz is obsolete and not used in many gateways.